### PR TITLE
chore: ESP-IDF の設定を更新

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -2,13 +2,13 @@
   "configurations": [
     {
       "name": "ESP-IDF",
-      "compilerPath": "${env:IDF_TOOLCHAIN_PATH}/xtensa-esp32s3-elf-gcc",
+      "compilerPath": "${env:HOME}/.espressif/tools/xtensa-esp-elf/esp-15.2.0_20251204/xtensa-esp-elf/bin/xtensa-esp32s3-elf-gcc",
       "compileCommands": "${workspaceFolder}/build/compile_commands.json",
       "includePath": [
         "${workspaceFolder}/main",
         "${workspaceFolder}/managed_components/**",
         "${workspaceFolder}/build/config",
-        "${config:idf.currentSetup}/components/**",
+        "${workspaceFolder}/components/**",
         "${workspaceFolder}/**"
       ],
       "defines": [
@@ -21,7 +21,7 @@
           "${workspaceFolder}/main",
           "${workspaceFolder}/managed_components",
           "${workspaceFolder}/build/config",
-          "${config:idf.currentSetup}/components",
+          "${workspaceFolder}/components",
           "${workspaceFolder}"
         ],
         "limitSymbolsToIncludedHeaders": true

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
-  "idf.currentSetup": "${env:IDF_PATH}",
+  "idf.currentSetup": "${env:HOME}/.espressif/v6.0/esp-idf",
   "idf.openOcdConfigs": ["board/esp32s3-builtin.cfg"],
   "idf.buildPath": "${workspaceFolder}/build",
   "idf.customExtraVars": {
@@ -10,9 +10,9 @@
   "clangd.arguments": [
     "--background-index",
     "--query-driver=**",
-    "--compile-commands-dir=/Users/kumata/Developer/prone-model/build"
+    "--compile-commands-dir=${workspaceFolder}/build"
   ],
   "idf.flashType": "UART",
-  "clangd.path": "/Users/kumata/.espressif/tools/esp-clang/esp-20.1.1_20250829/esp-clang/bin/clangd",
+  "clangd.path": "${env:HOME}/.espressif/tools/esp-clang/esp-20.1.1_20250829/esp-clang/bin/clangd",
   "idf.port": "/dev/tty.usbmodem5AB90112901"
 }


### PR DESCRIPTION
ESP-IDF v6.0.0 (eim) に上げたことに伴い、コンパイラパスとインクルードパスを環境変数に基づいて修正し、ビルドコマンドのディレクトリをワークスペースに合わせて変更しました。

<!-- PR レビューは日本語で行うこと -->